### PR TITLE
Fix 'TypeError: callback is not a function' in node.js filtered stream

### DIFF
--- a/Filtered-Stream/filtered_stream.js
+++ b/Filtered-Stream/filtered_stream.js
@@ -77,16 +77,12 @@ async function setRules() {
 }
 
 function streamConnect() {
-    //Listen to the stream
-    const options = {
-        timeout: 20000
-      }
-    
     const stream = needle.get(streamURL, {
         headers: { 
             Authorization: `Bearer ${token}`
-        }
-    }, options);
+        },
+        timeout: 20000
+    });
 
     stream.on('data', data => {
     try {


### PR DESCRIPTION
Fixes https://github.com/tomas/needle/issues/327.