### PR TITLE
Filtered stream fixes

### DIFF
--- a/Filtered-Stream/filtered_stream.js
+++ b/Filtered-Stream/filtered_stream.js
@@ -78,15 +78,13 @@ async function setRules() {
 
 function streamConnect() {
     //Listen to the stream
-    const options = {
-        timeout: 20000
-      }
-    
+
     const stream = needle.get(streamURL, {
         headers: { 
             Authorization: `Bearer ${token}`
-        }
-    }, options);
+        },
+        timeout: 20000
+    });
 
     stream.on('data', data => {
     try {
@@ -136,9 +134,9 @@ function streamConnect() {
       console.warn('A connection error occurred. Reconnecting…');
       setTimeout(() => {
         timeout++;
-        streamConnect(token);
+        streamConnect();
       }, 2 ** timeout);
-      streamConnect(token);
+      streamConnect();
     })
 
   })();


### PR DESCRIPTION
- streamConnect should not get any parameter on line 139, 141
- the third param of needle.get is not an object, but the options are the second param, where timeout should be too 