### PR TITLE
fix infinite loop in followers_lookup.js and following_lookup.js

### DIFF
--- a/Follows-Lookup/followers_lookup.js
+++ b/Follows-Lookup/followers_lookup.js
@@ -28,6 +28,8 @@ const getFollowers = async () => {
             }
             if (resp.meta.next_token) {
                 nextToken = resp.meta.next_token;
+            } else {
+                hasNextPage = false;
             }
         } else {
             hasNextPage = false;

--- a/Follows-Lookup/following_lookup.js
+++ b/Follows-Lookup/following_lookup.js
@@ -28,6 +28,8 @@ const getFollowing = async () => {
             }
             if (resp.meta.next_token) {
                 nextToken = resp.meta.next_token;
+            } else {
+                hasNextPage = false;
             }
         } else {
             hasNextPage = false;


### PR DESCRIPTION
both followers_lookup#getFollowers and following_lookup#getFollowing have a problem;
when api response data count is less than 1000 at first time, there is no timing to change hasNextPage flag to false.
as a result, while loop continues until API rate limit comes.
I guess those can be bugs thus I fixed them. thank you.