### PR TITLE
next_token changed to pagination_token

### DIFF
--- a/Follows-Lookup/followers_lookup.js
+++ b/Follows-Lookup/followers_lookup.js
@@ -48,7 +48,7 @@ const getFollowers = async () => {
 
 const getPage = async (params, options, nextToken) => {
     if (nextToken) {
-        params.next_token = nextToken;
+        params.pagination_token = nextToken;
     }
 
     try {


### PR DESCRIPTION
Code returned only the first page of followers and get an error 400 on the second page request.
Changing params to currently used pagination_token fixed an issue.