### PR TITLE
Handled ChunkedEncodingError in filtered_stream.py

### DIFF
--- a/Filtered-Stream/filtered_stream.py
+++ b/Filtered-Stream/filtered_stream.py
@@ -1,7 +1,7 @@
 import requests
 import os
 import json
-
+from requests.exceptions import ChunkedEncodingError
 # To set your enviornment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
 
@@ -63,20 +63,28 @@ def set_rules(headers, delete, bearer_token):
 
 
 def get_stream(headers, set, bearer_token):
-    response = requests.get(
-        "https://api.twitter.com/2/tweets/search/stream", headers=headers, stream=True,
-    )
-    print(response.status_code)
-    if response.status_code != 200:
-        raise Exception(
-            "Cannot get stream (HTTP {}): {}".format(
-                response.status_code, response.text
+    while True:
+        try:
+            response = requests.get(
+                "https://api.twitter.com/2/tweets/search/stream", headers=headers, stream=True,
             )
-        )
-    for response_line in response.iter_lines():
-        if response_line:
-            json_response = json.loads(response_line)
-            print(json.dumps(json_response, indent=4, sort_keys=True))
+            print(response.status_code)
+            if response.status_code != 200:
+                raise Exception(
+                    "Cannot get stream (HTTP {}): {}".format(
+                        response.status_code, response.text
+                    )
+                )
+            for response_line in response.iter_lines():
+                if response_line:
+                    json_response = json.loads(response_line)
+                    print(json.dumps(json_response, indent=4, sort_keys=True))
+        except KeyboardInterrupt as e:
+            raise SystemExit(e)
+        except ChunkedEncodingError:
+            continue
+        except Exception:
+            raise
 
 
 def main():


### PR DESCRIPTION
ChunkedEncodingError was raised every 5 mins due to some issue with the servers that the requests module couldn't handle.
The request to get the stream was wrapped in a try-except block and the entire code in `get_stream` is made to run forever using `while(True):`. Whenever a KeyboardInterrupt is raised using ctrl + C, the program and the stream gets suspended. When a ChunkedEncodingError is caught, the program execution continues with `continue`, thus causing the new request to the stream to be made automatically whenever ChunkedEncodingError is raised and caught. Finally any other Exceptions will be raised.

TO THE MAINTAINERS
This is my first pull request on GitHub on any repo. So please excuse me if I did not follow the proper format for this pull request. I've tested the code, in case you had any doubts regarding that. Thanks!

![twitterAPI](https://user-images.githubusercontent.com/46406720/120880671-4b852180-c5e9-11eb-9ec1-24a0ee924d78.png)
