### PR TITLE
Fix wrong usage of global var versus function arg

### DIFF
--- a/Recent-Search/recent_search.py
+++ b/Recent-Search/recent_search.py
@@ -19,7 +19,7 @@ def create_headers(bearer_token):
 
 
 def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", search_url, headers=headers, params=params)
+    response = requests.request("GET", url, headers=headers, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)


### PR DESCRIPTION
Currently in the connect_to_endpoint function, the variable 'search_url' in the GET request is used.
We should consider using the url parameter that is specified as an argument of the function.