### PR TITLE
Change Python Requests to use "auth=" parameter instead of "headers=" to authenticate the request

### DIFF
--- a/Follows-Lookup/followers_lookup.py
+++ b/Follows-Lookup/followers_lookup.py
@@ -4,10 +4,7 @@ import json
 
 # To set your environment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
-
-
-def auth():
-    return os.environ.get("BEARER_TOKEN")
+bearer_token = os.environ.get("BEARER_TOKEN")
 
 
 def create_url():
@@ -20,13 +17,18 @@ def get_params():
     return {"user.fields": "created_at"}
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2FollowersLookupPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", url, headers=headers, params=params)
+def connect_to_endpoint(url, params):
+    response = requests.request("GET", url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(
@@ -38,11 +40,9 @@ def connect_to_endpoint(url, headers, params):
 
 
 def main():
-    bearer_token = auth()
     url = create_url()
-    headers = create_headers(bearer_token)
     params = get_params()
-    json_response = connect_to_endpoint(url, headers, params)
+    json_response = connect_to_endpoint(url, params)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/Follows-Lookup/following_lookup.py
+++ b/Follows-Lookup/following_lookup.py
@@ -4,10 +4,7 @@ import json
 
 # To set your environment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
-
-
-def auth():
-    return os.environ.get("BEARER_TOKEN")
+bearer_token = os.environ.get("BEARER_TOKEN")
 
 
 def create_url():
@@ -20,13 +17,18 @@ def get_params():
     return {"user.fields": "created_at"}
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2FollowingLookupPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", url, headers=headers, params=params)
+def connect_to_endpoint(url, params):
+    response = requests.request("GET", url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(
@@ -38,11 +40,9 @@ def connect_to_endpoint(url, headers, params):
 
 
 def main():
-    bearer_token = auth()
     url = create_url()
-    headers = create_headers(bearer_token)
     params = get_params()
-    json_response = connect_to_endpoint(url, headers, params)
+    json_response = connect_to_endpoint(url, params)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/Full-Archive-Search/full-archive-search.py
+++ b/Full-Archive-Search/full-archive-search.py
@@ -13,13 +13,18 @@ search_url = "https://api.twitter.com/2/tweets/search/all"
 query_params = {'query': '(from:twitterdev -is:retweet) OR #twitterdev','tweet.fields': 'author_id'}
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2FullArchiveSearchPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", search_url, headers=headers, params=params)
+def connect_to_endpoint(url, params):
+    response = requests.request("GET", search_url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)
@@ -27,8 +32,7 @@ def connect_to_endpoint(url, headers, params):
 
 
 def main():
-    headers = create_headers(bearer_token)
-    json_response = connect_to_endpoint(search_url, headers, query_params)
+    json_response = connect_to_endpoint(search_url, query_params)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/Full-Archive-Tweet-Counts/full_archive_tweet_counts.py
+++ b/Full-Archive-Tweet-Counts/full_archive_tweet_counts.py
@@ -12,13 +12,18 @@ search_url = "https://api.twitter.com/2/tweets/counts/all"
 query_params = {'query': 'from:twitterdev','granularity': 'day', 'start_time': '2021-01-01T00:00:00Z'}
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2FullArchiveTweetCountsPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", search_url, headers=headers, params=params)
+def connect_to_endpoint(url, params):
+    response = requests.request("GET", search_url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)
@@ -26,8 +31,7 @@ def connect_to_endpoint(url, headers, params):
 
 
 def main():
-    headers = create_headers(bearer_token)
-    json_response = connect_to_endpoint(search_url, headers, query_params)
+    json_response = connect_to_endpoint(search_url, query_params)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/Likes-Lookup/liked_tweets.py
+++ b/Likes-Lookup/liked_tweets.py
@@ -4,10 +4,7 @@ import json
 
 # To set your enviornment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
-
-
-def auth():
-    return os.environ.get("BEARER_TOKEN")
+bearer_token = os.environ.get("BEARER_TOKEN")
 
 
 def create_url():
@@ -28,14 +25,19 @@ def create_url():
     return url, tweet_fields
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2LikedTweetsPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, tweet_fields):
+def connect_to_endpoint(url, tweet_fields):
     response = requests.request(
-        "GET", url, headers=headers, params=tweet_fields)
+        "GET", url, auth=bearer_oauth, params=tweet_fields)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(
@@ -47,10 +49,8 @@ def connect_to_endpoint(url, headers, tweet_fields):
 
 
 def main():
-    bearer_token = auth()
     url, tweet_fields = create_url()
-    headers = create_headers(bearer_token)
-    json_response = connect_to_endpoint(url, headers, tweet_fields)
+    json_response = connect_to_endpoint(url, tweet_fields)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/Likes-Lookup/liking_users.py
+++ b/Likes-Lookup/liking_users.py
@@ -4,10 +4,7 @@ import json
 
 # To set your enviornment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
-
-
-def auth():
-    return os.environ.get("BEARER_TOKEN")
+bearer_token = os.environ.get("BEARER_TOKEN")
 
 
 def create_url():
@@ -25,13 +22,18 @@ def create_url():
     return url, user_fields
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2LikingUsersPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, user_fields):
-    response = requests.request("GET", url, headers=headers, params=user_fields)
+def connect_to_endpoint(url, user_fields):
+    response = requests.request("GET", url, auth=bearer_oauth, params=user_fields)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(
@@ -43,10 +45,8 @@ def connect_to_endpoint(url, headers, user_fields):
 
 
 def main():
-    bearer_token = auth()
     url, tweet_fields = create_url()
-    headers = create_headers(bearer_token)
-    json_response = connect_to_endpoint(url, headers, tweet_fields)
+    json_response = connect_to_endpoint(url, tweet_fields)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/Recent-Search/recent_search.py
+++ b/Recent-Search/recent_search.py
@@ -13,13 +13,18 @@ search_url = "https://api.twitter.com/2/tweets/search/recent"
 query_params = {'query': '(from:twitterdev -is:retweet) OR #twitterdev','tweet.fields': 'author_id'}
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2RecentSearchPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", search_url, headers=headers, params=params)
+def connect_to_endpoint(url, params):
+    response = requests.get(search_url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)
@@ -27,8 +32,7 @@ def connect_to_endpoint(url, headers, params):
 
 
 def main():
-    headers = create_headers(bearer_token)
-    json_response = connect_to_endpoint(search_url, headers, query_params)
+    json_response = connect_to_endpoint(search_url, query_params)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/Recent-Tweet-Counts/recent_tweet_counts.py
+++ b/Recent-Tweet-Counts/recent_tweet_counts.py
@@ -12,13 +12,18 @@ search_url = "https://api.twitter.com/2/tweets/counts/recent"
 query_params = {'query': 'from:twitterdev','granularity': 'day'}
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2RecentTweetCountsPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", search_url, headers=headers, params=params)
+def connect_to_endpoint(url, params):
+    response = requests.request("GET", search_url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)
@@ -26,8 +31,7 @@ def connect_to_endpoint(url, headers, params):
 
 
 def main():
-    headers = create_headers(bearer_token)
-    json_response = connect_to_endpoint(search_url, headers, query_params)
+    json_response = connect_to_endpoint(search_url, query_params)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/Sampled-Stream/sampled-stream.py
+++ b/Sampled-Stream/sampled-stream.py
@@ -4,23 +4,25 @@ import json
 
 # To set your environment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
-
-
-def auth():
-    return os.environ.get("BEARER_TOKEN")
+bearer_token = os.environ.get("BEARER_TOKEN")
 
 
 def create_url():
     return "https://api.twitter.com/2/tweets/sample/stream"
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2SampledStreamPython"
+    return r
 
 
-def connect_to_endpoint(url, headers):
-    response = requests.request("GET", url, headers=headers, stream=True)
+def connect_to_endpoint(url):
+    response = requests.request("GET", url, auth=bearer_oauth, stream=True)
     print(response.status_code)
     for response_line in response.iter_lines():
         if response_line:
@@ -35,12 +37,10 @@ def connect_to_endpoint(url, headers):
 
 
 def main():
-    bearer_token = auth()
     url = create_url()
-    headers = create_headers(bearer_token)
     timeout = 0
     while True:
-        connect_to_endpoint(url, headers)
+        connect_to_endpoint(url)
         timeout += 1
 
 

--- a/Tweet-Lookup/get_tweets_with_bearer_token.py
+++ b/Tweet-Lookup/get_tweets_with_bearer_token.py
@@ -4,10 +4,7 @@ import json
 
 # To set your enviornment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
-
-
-def auth():
-    return os.environ.get("BEARER_TOKEN")
+bearer_token = os.environ.get("BEARER_TOKEN")
 
 
 def create_url():
@@ -26,13 +23,18 @@ def create_url():
     return url
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2TweetLookupPython"
+    return r
 
 
-def connect_to_endpoint(url, headers):
-    response = requests.request("GET", url, headers=headers)
+def connect_to_endpoint(url):
+    response = requests.request("GET", url, auth=bearer_oauth)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(
@@ -44,10 +46,8 @@ def connect_to_endpoint(url, headers):
 
 
 def main():
-    bearer_token = auth()
     url = create_url()
-    headers = create_headers(bearer_token)
-    json_response = connect_to_endpoint(url, headers)
+    json_response = connect_to_endpoint(url)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/User-Lookup/get_users_with_bearer_token.py
+++ b/User-Lookup/get_users_with_bearer_token.py
@@ -4,10 +4,7 @@ import json
 
 # To set your enviornment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
-
-
-def auth():
-    return os.environ.get("BEARER_TOKEN")
+bearer_token = os.environ.get("BEARER_TOKEN")
 
 
 def create_url():
@@ -23,13 +20,18 @@ def create_url():
     return url
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2UserLookupPython"
+    return r
 
 
-def connect_to_endpoint(url, headers):
-    response = requests.request("GET", url, headers=headers)
+def connect_to_endpoint(url):
+    response = requests.request("GET", url, auth=bearer_oauth,)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(
@@ -41,10 +43,8 @@ def connect_to_endpoint(url, headers):
 
 
 def main():
-    bearer_token = auth()
     url = create_url()
-    headers = create_headers(bearer_token)
-    json_response = connect_to_endpoint(url, headers)
+    json_response = connect_to_endpoint(url)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/User-Mention-Timeline/user_mentions.py
+++ b/User-Mention-Timeline/user_mentions.py
@@ -4,10 +4,7 @@ import json
 
 # To set your environment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
-
-
-def auth():
-    return os.environ.get("BEARER_TOKEN")
+bearer_token = os.environ.get("BEARER_TOKEN")
 
 
 def create_url():
@@ -27,13 +24,18 @@ def get_params():
     return {"tweet.fields": "created_at"}
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2UserMentionsPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", url, headers=headers, params=params)
+def connect_to_endpoint(url, params):
+    response = requests.request("GET", url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(
@@ -45,11 +47,9 @@ def connect_to_endpoint(url, headers, params):
 
 
 def main():
-    bearer_token = auth()
     url = create_url()
-    headers = create_headers(bearer_token)
     params = get_params()
-    json_response = connect_to_endpoint(url, headers, params)
+    json_response = connect_to_endpoint(url, params)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 

--- a/User-Tweet-Timeline/user_tweets.py
+++ b/User-Tweet-Timeline/user_tweets.py
@@ -4,10 +4,7 @@ import json
 
 # To set your environment variables in your terminal run the following line:
 # export 'BEARER_TOKEN'='<your_bearer_token>'
-
-
-def auth():
-    return os.environ.get("BEARER_TOKEN")
+bearer_token = os.environ.get("BEARER_TOKEN")
 
 
 def create_url():
@@ -27,13 +24,18 @@ def get_params():
     return {"tweet.fields": "created_at"}
 
 
-def create_headers(bearer_token):
-    headers = {"Authorization": "Bearer {}".format(bearer_token)}
-    return headers
+def bearer_oauth(r):
+    """
+    Method required by bearer token authentication.
+    """
+
+    r.headers["Authorization"] = f"Bearer {bearer_token}"
+    r.headers["User-Agent"] = "v2UserTweetsPython"
+    return r
 
 
-def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", url, headers=headers, params=params)
+def connect_to_endpoint(url, params):
+    response = requests.request("GET", url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(
@@ -45,11 +47,9 @@ def connect_to_endpoint(url, headers, params):
 
 
 def main():
-    bearer_token = auth()
     url = create_url()
-    headers = create_headers(bearer_token)
     params = get_params()
-    json_response = connect_to_endpoint(url, headers, params)
+    json_response = connect_to_endpoint(url, params)
     print(json.dumps(json_response, indent=4, sort_keys=True))
 
 


### PR DESCRIPTION
As per the [Python Requests documentation](https://docs.python-requests.org/en/master/user/quickstart/) 

> Authorization headers set with headers= will be overridden if credentials are specified in .netrc, which in turn will be overridden by the auth= parameter. Requests will search for the netrc file at ~/.netrc, ~/_netrc, or at the path specified by the NETRC environment variable.

Given the above, I changed all Python files in this repo that use OAuth 2.0 Bearer token to use the "auth=" parameter instead of the "headers=" parameter. 