### PR TITLE
Let connect_to_endpoint in full-archive-search.py actually use the url parameter

### DIFF
--- a/Full-Archive-Search/full-archive-search.py
+++ b/Full-Archive-Search/full-archive-search.py
@@ -24,7 +24,7 @@ def bearer_oauth(r):
 
 
 def connect_to_endpoint(url, params):
-    response = requests.request("GET", search_url, auth=bearer_oauth, params=params)
+    response = requests.request("GET", url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)


### PR DESCRIPTION
The method connect_to_endpoint in full-archive-search.py defines the parameter url but never uses it.

This PR let connect_to_endpoint use url in full-archive-search.py