### PR TITLE
Fix 401 unauthorized error

### DIFF
--- a/Manage-Tweets/delete_tweet.py
+++ b/Manage-Tweets/delete_tweet.py
@@ -16,7 +16,7 @@ id = "tweet-id-to-delete"
 
 
 # Get request token
-request_token_url = "https://api.twitter.com/oauth/request_token"
+request_token_url = "https://api.twitter.com/oauth/request_token?oauth_callback=oob&x_auth_access_type=write"
 oauth = OAuth1Session(consumer_key, client_secret=consumer_secret)
 
 try:


### PR DESCRIPTION
Fix 401 unauthorized error by missed write permission
----
$ python3 delete_tweet.py
Traceback (most recent call last):
  File "delete_tweet.py", line 67, in <module>
    raise Exception(
Exception: Request returned an error: 401 {
  "title": "Unauthorized",
  "type": "about:blank",
  "status": 401,
  "detail": "Unauthorized"
}