### PR TITLE
UTF-8 encoding to rules

### DIFF
--- a/Filtered-Stream/FilteredStreamDemo.java
+++ b/Filtered-Stream/FilteredStreamDemo.java
@@ -89,7 +89,7 @@ public class FilteredStreamDemo {
     HttpPost httpPost = new HttpPost(uriBuilder.build());
     httpPost.setHeader("Authorization", String.format("Bearer %s", bearerToken));
     httpPost.setHeader("content-type", "application/json");
-    StringEntity body = new StringEntity(getFormattedString("{\"add\": [%s]}", rules));
+    StringEntity body = new StringEntity(getFormattedString("{\"add\": [%s]}", rules),  "UTF-8");
     httpPost.setEntity(body);
     HttpResponse response = httpClient.execute(httpPost);
     HttpEntity entity = response.getEntity();


### PR DESCRIPTION
Without this addition, the rules cannot accept words that contain non ASCII characters (for example the word siccità) and the API returns the error "{"errors":[{"parameters":{},"message":"Invalid JSON"}],"title":"Invalid Request","detail":"One or more parameters to your request was invalid.","type":"https://api.twitter.com/2/problems/invalid-request"}"