### PR TITLE
Fix response object name

### DIFF
--- a/User-Lookup/get_users_with_bearer_token.r
+++ b/User-Lookup/get_users_with_bearer_token.r
@@ -16,5 +16,5 @@ response <-
             httr::add_headers(.headers = headers),
             query = params)
 
-obj <- httr::content(res, as = "text")
+obj <- httr::content(response, as = "text")
 print(obj)


### PR DESCRIPTION
Update the `response` object name used by `httr::content()` from `res` to `response`.