### PR TITLE
Additional occurrences of issue from PR #38

### DIFF
--- a/Full-Archive-Search/full-archive-search.py
+++ b/Full-Archive-Search/full-archive-search.py
@@ -24,7 +24,7 @@ def bearer_oauth(r):
 
 
 def connect_to_endpoint(url, params):
-    response = requests.request("GET", search_url, auth=bearer_oauth, params=params)
+    response = requests.request("GET", url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)

--- a/Full-Archive-Tweet-Counts/full_archive_tweet_counts.py
+++ b/Full-Archive-Tweet-Counts/full_archive_tweet_counts.py
@@ -23,7 +23,7 @@ def bearer_oauth(r):
 
 
 def connect_to_endpoint(url, params):
-    response = requests.request("GET", search_url, auth=bearer_oauth, params=params)
+    response = requests.request("GET", url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)

--- a/Recent-Tweet-Counts/recent_tweet_counts.py
+++ b/Recent-Tweet-Counts/recent_tweet_counts.py
@@ -23,7 +23,7 @@ def bearer_oauth(r):
 
 
 def connect_to_endpoint(url, params):
-    response = requests.request("GET", search_url, auth=bearer_oauth, params=params)
+    response = requests.request("GET", url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)

--- a/Search-Spaces/search_spaces.py
+++ b/Search-Spaces/search_spaces.py
@@ -23,7 +23,7 @@ def create_headers(bearer_token):
 
 
 def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", search_url, headers=headers, params=params)
+    response = requests.request("GET", url, headers=headers, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)

--- a/Spaces-Lookup/spaces_lookup.py
+++ b/Spaces-Lookup/spaces_lookup.py
@@ -21,7 +21,7 @@ def create_headers(bearer_token):
 
 
 def connect_to_endpoint(url, headers, params):
-    response = requests.request("GET", search_url, headers=headers, params=params)
+    response = requests.request("GET", url, headers=headers, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)


### PR DESCRIPTION
Module-scope variable "search_url" is used in place of function arg "url" in connect_to_endpoint function (five occurrences).

An additional occurence was fixed by PR #38