### PR TITLE
Fix typo in delete_tweet.js

### DIFF
--- a/Manage-Tweets/delete_tweet.js
+++ b/Manage-Tweets/delete_tweet.js
@@ -105,7 +105,7 @@ async function getRequest({ oauth_token, oauth_token_secret }) {
     headers: {
       Authorization: authHeader["Authorization"],
       "user-agent": "v2DeleteTweetJS",
-      "content-type": "application/json"
+      "content-type": "application/json",
       accept: "application/json",
     },
   });


### PR DESCRIPTION
I fixed the typo in the original code because it was causing an error.