### PR TITLE
Update syntax in create_tweet.rb

### DIFF
--- a/Manage-Tweets/create_tweet.rb
+++ b/Manage-Tweets/create_tweet.rb
@@ -31,7 +31,7 @@ end
 def get_user_authorization(request_token)
 	puts "Follow this URL to have a user authorize your app: #{request_token.authorize_url()}"
 	puts "Enter PIN: "
-	pin = gets.strip
+	pin = $stdin.gets.strip
 
   return pin
 end


### PR DESCRIPTION
Kernel#gets is not a method to read from stdin.

Use `$stdin.gets` instead

`gets` reads from argument input

Screenshot shows the current code fails to run because gets tries to parse argument input ARGV

![image](https://github.com/twitterdev/Twitter-API-v2-sample-code/assets/53415386/e82878f5-3350-48eb-b051-191f6731f1ee)

Change to `$stdin.gets` solves this problem