### PR TITLE
Bug fix in recent_tweet_counts.py

### DIFF
--- a/Recent-Tweet-Counts/recent_tweet_counts.py
+++ b/Recent-Tweet-Counts/recent_tweet_counts.py
@@ -23,7 +23,7 @@ def bearer_oauth(r):
 
 
 def connect_to_endpoint(url, params):
-    response = requests.request("GET", search_url, auth=bearer_oauth, params=params)
+    response = requests.request("GET", url, auth=bearer_oauth, params=params)
     print(response.status_code)
     if response.status_code != 200:
         raise Exception(response.status_code, response.text)


### PR DESCRIPTION
In the connect_to_endpoint function, we should use the url parameter instead of search_url when making the request.