### PR TITLE
Update README with installation command

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -12,7 +12,9 @@ node --version
 
 ### 2. Install dependencies
 
-No package.json is required. Examples use Node.js built-in modules or standard libraries.
+```
+npm install @xdevplatform/xdk
+```
 
 ### 3. Set environment variables
 


### PR DESCRIPTION
The README for javascript examples wrongly stated that no dependencies are needed.